### PR TITLE
add figures graphicspath; support RequirePackage in usepackages

### DIFF
--- a/latexpp/fixes/figures.py
+++ b/latexpp/fixes/figures.py
@@ -40,13 +40,14 @@ class CopyAndRenameFigs(BaseFix):
     """
 
     def __init__(self, fig_rename='fig-{fig_counter:02}{fig_ext}',
-                 start_fig_counter=1):
+                 start_fig_counter=1, graphicspath="."):
         super().__init__()
 
         # By default we start at Fig #1 because journals like separate files
         # with numbered figures starting at 1
         self.fig_counter = start_fig_counter
         self.fig_rename = fig_rename
+        self.graphicspath = graphicspath
 
     def fix_node(self, n, **kwargs):
 
@@ -55,6 +56,7 @@ class CopyAndRenameFigs(BaseFix):
 
             # find file and copy it
             orig_fig_name = self.preprocess_arg_latex(n, 1)
+            orig_fig_name = os_path.join(self.graphicspath, orig_fig_name)
             for e in exts:
                 if os_path.exists(orig_fig_name+e):
                     orig_fig_name = orig_fig_name+e

--- a/latexpp/fixes/usepackage.py
+++ b/latexpp/fixes/usepackage.py
@@ -5,6 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from pylatexenc.latexwalker import LatexMacroNode
+from pylatexenc.macrospec import std_macro
 
 from latexpp.fix import BaseFix
 
@@ -14,11 +15,10 @@ def node_get_usepackage(n, fix):
     If `n` is a macro node that is a 'usepackage' directive, then this function
     returns a string with the package name.  Otherwise we return `None`.
     """
-    if n.isNodeType(LatexMacroNode) and n.macroname == 'usepackage' and \
-       n.nodeargd is not None and n.nodeargd.argnlist is not None:
+    if (n.isNodeType(LatexMacroNode) and n.macroname in ("usepackage", "RequirePackage") 
+        and n.nodeargd is not None and n.nodeargd.argnlist is not None):
         # usepackage has signature '[{'
         return fix.preprocess_arg_latex(n, 1).strip()
-
     return None
 
 
@@ -49,6 +49,11 @@ class RemovePkgs(BaseFix):
             return [] # kill entire node
 
         return None
+
+    def specs(self):
+        return {
+            "macros": [std_macro("RequirePackage", True, 1)]
+        }
 
 
 class CopyLocalPkgs(BaseFix):
@@ -81,6 +86,11 @@ class CopyLocalPkgs(BaseFix):
                 return None # keep node the same
 
         return None
+
+    def specs(self):
+        return {
+            "macros": [std_macro("RequirePackage", True, 1)]
+        }
 
 
 class InputLocalPkgs(BaseFix):
@@ -156,3 +166,8 @@ class InputLocalPkgs(BaseFix):
 
     def finalize(self):
         self.subpp.finalize()
+
+    def specs(self):
+        return {
+            "macros": [std_macro("RequirePackage", True, 1)]
+        }

--- a/test/test_fixes_usepackage.py
+++ b/test/test_fixes_usepackage.py
@@ -42,13 +42,14 @@ class TestCopyLocalPkgs(unittest.TestCase):
 
     def test_simple(self):
         
-        usepackage.os_path = helpers.FakeOsPath([
+        mock_files = {
             # list of files that "exist"
-            'mymacros.sty',
-            'cleveref.sty',
-        ])        
+            "mymacros.sty": "%test",
+            "cleveref.sty": "%test",
+        }
+        usepackage.os_path = helpers.FakeOsPath(list(mock_files.keys()))
 
-        lpp = helpers.MockLPP()
+        lpp = helpers.MockLPP(mock_files)
         lpp.install_fix( usepackage.CopyLocalPkgs() )
 
         lpp.execute(r"""
@@ -63,12 +64,11 @@ class TestCopyLocalPkgs(unittest.TestCase):
 Hello world.
 \end{document}
 """)
-
         self.assertEqual(
             lpp.copied_files,
             [
-                ('mymacros.sty', '/TESTOUT'),
-                ('cleveref.sty', '/TESTOUT'),
+                ('mymacros.sty', '/TESTOUT/mymacros.sty'),
+                ('cleveref.sty', '/TESTOUT/cleveref.sty'),
             ]
         )
 


### PR DESCRIPTION
This PR augments two fixes:
- figures: add optional `graphicspath` argument. This has the effect of prepending `graphicspath` to all includegraphics's paths. This is to handle the \graphicspath command [Ref: https://texblog.org/2017/12/05/the-path-to-your-figures/]
- usepackages: 
  - support the \RequirePackage macro in addition to \usepackage
  - for copyLocalPackage, support recursively copying required local packages 